### PR TITLE
Support `Bus::dispatchChain`

### DIFF
--- a/src/EventVisualizer.php
+++ b/src/EventVisualizer.php
@@ -74,7 +74,7 @@ class EventVisualizer
                 continue;
             }
 
-            if (!$this->showLaravelEvents && !Str::startsWith($event, 'App')) {
+            if (! $this->showLaravelEvents && ! Str::startsWith($event, 'App')) {
                 continue; // Get only our own events, not the default laravel ones
             }
 
@@ -179,6 +179,7 @@ class EventVisualizer
         ];
         $methods = [
             'dispatch',
+            'dispatchChain',
             'dispatchNow',
             'dispatchSync',
             'dispatchToQueue',

--- a/src/Services/CodeParser/CodeParser.php
+++ b/src/Services/CodeParser/CodeParser.php
@@ -219,6 +219,10 @@ class CodeParser
             return [$this->getFullyQualifiedClassName($argument->value->class->toString())];
         }
 
+        if ($argument->value instanceof Array_) {
+            return collect($argument->value->items)->map(fn (ArrayItem $item) => $this->getFullyQualifiedClassName($item->value->class->toString()))->all();
+        }
+
         return [];
     }
 

--- a/src/Services/CodeParser/CodeParser.php
+++ b/src/Services/CodeParser/CodeParser.php
@@ -107,7 +107,9 @@ class CodeParser
                 throw new Exception('Static calls within method calls are not supported yet. If this is a Bus::chain, support is coming.');
             }
 
-            throw new Exception('Not supported yet. Please open an issue here: https://github.com/JonasPardon/laravel-event-visualizer/issues/new');
+            // throw new Exception('Not supported yet. Please open an issue here: https://github.com/JonasPardon/laravel-event-visualizer/issues/new');
+
+            return false;
         });
 
         return collect($calls)->map(function (MethodCall $node) use ($subjectClass) {

--- a/tests/Unit/CodeParser/ArgumentResolverTest.php
+++ b/tests/Unit/CodeParser/ArgumentResolverTest.php
@@ -5,6 +5,7 @@ namespace JonasPardon\LaravelEventVisualizer\Tests\Unit\CodeParser;
 use JonasPardon\LaravelEventVisualizer\Services\CodeParser\CodeParser;
 use JonasPardon\LaravelEventVisualizer\Tests\TestCase;
 use PhpParser\Node\Arg;
+use PhpParser\Node\Expr\StaticCall;
 use PhpParser\NodeFinder;
 use PhpParser\NodeTraverser;
 use PhpParser\Parser;
@@ -46,9 +47,10 @@ final class ArgumentResolverTest extends TestCase
 
         /** @var Arg $argument */
         $argument = $this->nodeFinder->findFirstInstanceOf($nodes, Arg::class);
-        $resolvedClass = $codeParser->resolveClassesFromArgument($argument);
+        $resolvedClasses = $codeParser->resolveClassesFromArgument($argument);
 
-        $this->assertEquals('App\Events\SomeEvent', $resolvedClass[0]);
+        $this->assertCount(1, $resolvedClasses);
+        $this->assertEquals('App\Events\SomeEvent', $resolvedClasses[0]);
     }
 
     /** @test */
@@ -74,9 +76,10 @@ final class ArgumentResolverTest extends TestCase
 
         /** @var Arg $argument */
         $argument = $this->nodeFinder->findFirstInstanceOf($nodes, Arg::class);
-        $resolvedClass = $codeParser->resolveClassesFromArgument($argument);
+        $resolvedClasses = $codeParser->resolveClassesFromArgument($argument);
 
-        $this->assertEquals('App\Events\SomeEvent', $resolvedClass[0]);
+        $this->assertCount(1, $resolvedClasses);
+        $this->assertEquals('App\Events\SomeEvent', $resolvedClasses[0]);
     }
 
     /** @test */
@@ -102,9 +105,10 @@ final class ArgumentResolverTest extends TestCase
 
         /** @var Arg $argument */
         $argument = $this->nodeFinder->findFirstInstanceOf($nodes, Arg::class);
-        $resolvedClass = $codeParser->resolveClassesFromArgument($argument);
+        $resolvedClasses = $codeParser->resolveClassesFromArgument($argument);
 
-        $this->assertEquals('App\Events\SomeEvent', $resolvedClass[0]);
+        $this->assertCount(1, $resolvedClasses);
+        $this->assertEquals('App\Events\SomeEvent', $resolvedClasses[0]);
     }
 
     /** @test */
@@ -129,9 +133,10 @@ final class ArgumentResolverTest extends TestCase
 
         /** @var Arg $argument */
         $argument = $this->nodeFinder->findFirstInstanceOf($nodes, Arg::class);
-        $resolvedClass = $codeParser->resolveClassesFromArgument($argument);
+        $resolvedClasses = $codeParser->resolveClassesFromArgument($argument);
 
-        $this->assertEquals('App\Events\SomeEvent', $resolvedClass[0]);
+        $this->assertCount(1, $resolvedClasses);
+        $this->assertEquals('App\Events\SomeEvent', $resolvedClasses[0]);
     }
 
     /** @test */
@@ -158,9 +163,10 @@ final class ArgumentResolverTest extends TestCase
 
         /** @var Arg $argument */
         $argument = $this->nodeFinder->findFirstInstanceOf($nodes, Arg::class);
-        $resolvedClass = $codeParser->resolveClassesFromArgument($argument);
+        $resolvedClasses = $codeParser->resolveClassesFromArgument($argument);
 
-        $this->assertEquals('App\Events\SomeEvent', $resolvedClass[0]);
+        $this->assertCount(1, $resolvedClasses);
+        $this->assertEquals('App\Events\SomeEvent', $resolvedClasses[0]);
     }
 
     /** @test */
@@ -187,8 +193,42 @@ final class ArgumentResolverTest extends TestCase
 
         /** @var Arg $argument */
         $argument = $this->nodeFinder->findFirstInstanceOf($nodes, Arg::class);
-        $resolvedClass = $codeParser->resolveClassesFromArgument($argument);
+        $resolvedClasses = $codeParser->resolveClassesFromArgument($argument);
 
-        $this->assertEquals('App\Events\SomeEvent', $resolvedClass[0]);
+        $this->assertCount(1, $resolvedClasses);
+        $this->assertEquals('App\Events\SomeEvent', $resolvedClasses[0]);
     }
+
+    /** @test */
+    public function it_can_resolve_the_classes_of_an_array_of_jobs(): void
+    {
+        $code = <<<'CODE'
+            <?php
+
+            use Some\Namespace\SomeClass;
+            use Some\Namespace\SomeOtherClass;
+            use \Bus;
+
+            class ClassName
+            {
+                public function someMethod()
+                {
+                    Bus::dispatchChain([new Some\Namespace\SomeClass(), new Some\Namespace\SomeOtherClass()]);
+                }
+            }
+            CODE;
+
+        $codeParser = new CodeParser($code);
+        $syntaxTree = $this->parser->parse($code);
+        $nodes = $this->nodeTraverser->traverse($syntaxTree);
+
+        /** @var Arg $argument */
+        $argument = $this->nodeFinder->findFirstInstanceOf($nodes, StaticCall::class)->args[0];
+
+        $resolvedClasses = $codeParser->resolveClassesFromArgument($argument);
+
+        $this->assertCount(2, $resolvedClasses);
+        $this->assertEquals(['Some\Namespace\SomeClass', 'Some\Namespace\SomeOtherClass'], $resolvedClasses);
+    }
+
 }

--- a/tests/Unit/CodeParser/ArgumentResolverTest.php
+++ b/tests/Unit/CodeParser/ArgumentResolverTest.php
@@ -30,7 +30,7 @@ final class ArgumentResolverTest extends TestCase
     {
         $code = <<<'CODE'
             <?php
-            
+
             class ClassName
             {
                 public function someMethod()
@@ -46,9 +46,9 @@ final class ArgumentResolverTest extends TestCase
 
         /** @var Arg $argument */
         $argument = $this->nodeFinder->findFirstInstanceOf($nodes, Arg::class);
-        $resolvedClass = $codeParser->resolveClassFromArgument($argument);
+        $resolvedClass = $codeParser->resolveClassesFromArgument($argument);
 
-        $this->assertEquals('App\Events\SomeEvent', $resolvedClass);
+        $this->assertEquals('App\Events\SomeEvent', $resolvedClass[0]);
     }
 
     /** @test */
@@ -56,9 +56,9 @@ final class ArgumentResolverTest extends TestCase
     {
         $code = <<<'CODE'
             <?php
-            
+
             use App\Events\SomeEvent;
-            
+
             class ClassName
             {
                 public function someMethod()
@@ -74,9 +74,9 @@ final class ArgumentResolverTest extends TestCase
 
         /** @var Arg $argument */
         $argument = $this->nodeFinder->findFirstInstanceOf($nodes, Arg::class);
-        $resolvedClass = $codeParser->resolveClassFromArgument($argument);
+        $resolvedClass = $codeParser->resolveClassesFromArgument($argument);
 
-        $this->assertEquals('App\Events\SomeEvent', $resolvedClass);
+        $this->assertEquals('App\Events\SomeEvent', $resolvedClass[0]);
     }
 
     /** @test */
@@ -84,9 +84,9 @@ final class ArgumentResolverTest extends TestCase
     {
         $code = <<<'CODE'
             <?php
-            
+
             use App\Events\SomeEvent as SomeEventAlias;
-            
+
             class ClassName
             {
                 public function someMethod()
@@ -102,9 +102,9 @@ final class ArgumentResolverTest extends TestCase
 
         /** @var Arg $argument */
         $argument = $this->nodeFinder->findFirstInstanceOf($nodes, Arg::class);
-        $resolvedClass = $codeParser->resolveClassFromArgument($argument);
+        $resolvedClass = $codeParser->resolveClassesFromArgument($argument);
 
-        $this->assertEquals('App\Events\SomeEvent', $resolvedClass);
+        $this->assertEquals('App\Events\SomeEvent', $resolvedClass[0]);
     }
 
     /** @test */
@@ -112,7 +112,7 @@ final class ArgumentResolverTest extends TestCase
     {
         $code = <<<'CODE'
             <?php
-            
+
             class ClassName
             {
                 public function someMethod()
@@ -129,9 +129,9 @@ final class ArgumentResolverTest extends TestCase
 
         /** @var Arg $argument */
         $argument = $this->nodeFinder->findFirstInstanceOf($nodes, Arg::class);
-        $resolvedClass = $codeParser->resolveClassFromArgument($argument);
+        $resolvedClass = $codeParser->resolveClassesFromArgument($argument);
 
-        $this->assertEquals('App\Events\SomeEvent', $resolvedClass);
+        $this->assertEquals('App\Events\SomeEvent', $resolvedClass[0]);
     }
 
     /** @test */
@@ -139,9 +139,9 @@ final class ArgumentResolverTest extends TestCase
     {
         $code = <<<'CODE'
             <?php
-            
+
             use \App\Events\SomeEvent;
-            
+
             class ClassName
             {
                 public function someMethod()
@@ -158,9 +158,9 @@ final class ArgumentResolverTest extends TestCase
 
         /** @var Arg $argument */
         $argument = $this->nodeFinder->findFirstInstanceOf($nodes, Arg::class);
-        $resolvedClass = $codeParser->resolveClassFromArgument($argument);
+        $resolvedClass = $codeParser->resolveClassesFromArgument($argument);
 
-        $this->assertEquals('App\Events\SomeEvent', $resolvedClass);
+        $this->assertEquals('App\Events\SomeEvent', $resolvedClass[0]);
     }
 
     /** @test */
@@ -168,9 +168,9 @@ final class ArgumentResolverTest extends TestCase
     {
         $code = <<<'CODE'
             <?php
-            
+
             use \App\Events\SomeEvent as SomeEventAlias;
-            
+
             class ClassName
             {
                 public function someMethod()
@@ -187,8 +187,8 @@ final class ArgumentResolverTest extends TestCase
 
         /** @var Arg $argument */
         $argument = $this->nodeFinder->findFirstInstanceOf($nodes, Arg::class);
-        $resolvedClass = $codeParser->resolveClassFromArgument($argument);
+        $resolvedClass = $codeParser->resolveClassesFromArgument($argument);
 
-        $this->assertEquals('App\Events\SomeEvent', $resolvedClass);
+        $this->assertEquals('App\Events\SomeEvent', $resolvedClass[0]);
     }
 }


### PR DESCRIPTION
This adds support for `Bus::dispatchChain`. This change introduces the idea that multiple classes can be resolved rather than a single class.

Tests are added for an array of jobs as an argument or assigned to a variable.

I've also removed the exception when an unsupported dispatch call is encountered in order to avoid exiting early.

See #8 for some discussion about this.