### PR TITLE
Connect interfaces to event classes in graph

### DIFF
--- a/src/EventVisualizer.php
+++ b/src/EventVisualizer.php
@@ -91,6 +91,31 @@ class EventVisualizer
                 $this->analyseClass($listener);
             }
         }
+
+        foreach (array_keys($events) as $event) {
+            if ($this->isIgnored($event)) {
+                continue;
+            }
+
+            if (! $this->showLaravelEvents && ! Str::startsWith($event, 'App')) {
+                continue; // Get only our own events, not the default laravel ones
+            }
+
+            foreach (array_keys($events) as $interface) {
+                if ($this->isIgnored($interface)) {
+                    continue;
+                }
+
+                if (! is_subclass_of($event, $interface)) {
+                    continue;
+                }
+
+                $this->connectNodes(
+                    from: new Event($interface),
+                    to: new Event($event),
+                );
+            }
+        }
     }
 
     private function analyseClass(string $className): void


### PR DESCRIPTION
When listeners and subscribers use an interface or subclass type hint, it's unclear which concrete event classes are associated with those listeners and subscribers.

This update connects the base classes/interfaces to the concrete event classes and then those concrete classes are connected to the listeners and subscribers in the graph.

Additional discussion in #8 

| Before  | After |
| ------------- | ------------- |
| ![Before](https://github.com/JonasPardon/laravel-event-visualizer/assets/129096/0233fa21-f7df-432d-b084-a6ce012a89f2)  | ![After](https://github.com/JonasPardon/laravel-event-visualizer/assets/129096/0d18e0b6-e856-462b-90ca-ebca2992564b)  |



