### PR TITLE
Handle invokable actions

### DIFF
--- a/src/Services/CodeParser/CodeParser.php
+++ b/src/Services/CodeParser/CodeParser.php
@@ -129,13 +129,10 @@ class CodeParser
     public function getFunctionCalls(string $functionName): array
     {
         $calls = $this->nodeFinder->find($this->nodes, function (Node $node) use ($functionName) {
-            try{
-                return $node instanceof Expression &&
-                    $node->expr instanceof FuncCall &&
-                    $node->expr->name->toString() === $functionName;
-            } catch (Throwable) {
-                return false;
-            }
+            return $node instanceof Expression &&
+                $node->expr instanceof FuncCall &&
+                $node->expr->name instanceof \PhpParser\Node\Name &&
+                $node->expr->name->toString() === $functionName;
         });
 
         return collect($calls)->map(function (Expression $node) use ($functionName) {

--- a/src/Services/CodeParser/CodeParser.php
+++ b/src/Services/CodeParser/CodeParser.php
@@ -15,6 +15,7 @@ use PhpParser\Node\Expr\New_;
 use PhpParser\Node\Expr\PropertyFetch;
 use PhpParser\Node\Expr\StaticCall;
 use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Identifier;
 use PhpParser\Node\Name\FullyQualified;
 use PhpParser\Node\Stmt\ClassMethod;
 use PhpParser\Node\Stmt\Expression;
@@ -24,6 +25,7 @@ use PhpParser\NodeFinder;
 use PhpParser\NodeTraverser;
 use PhpParser\Parser;
 use PhpParser\ParserFactory;
+use Throwable;
 
 class CodeParser
 {
@@ -127,9 +129,13 @@ class CodeParser
     public function getFunctionCalls(string $functionName): array
     {
         $calls = $this->nodeFinder->find($this->nodes, function (Node $node) use ($functionName) {
-            return $node instanceof Expression &&
-                $node->expr instanceof FuncCall &&
-                $node->expr->name->toString() === $functionName;
+            try{
+                return $node instanceof Expression &&
+                    $node->expr instanceof FuncCall &&
+                    $node->expr->name->toString() === $functionName;
+            } catch (Throwable) {
+                return false;
+            }
         });
 
         return collect($calls)->map(function (Expression $node) use ($functionName) {

--- a/tests/Unit/CodeParser/StaticCallsParsingTest.php
+++ b/tests/Unit/CodeParser/StaticCallsParsingTest.php
@@ -34,13 +34,13 @@ final class StaticCallsParsingTest extends TestCase
             'static dispatch call on Event facade without import' => [
                 <<<'CODE'
                 <?php declare(strict_types=1);
-                
+
                 final class ClassName
                 {
                     public function __construct()
                     {
                     }
-                
+
                     public function classMethod(): void
                     {
                         \Event::dispatch(new \App\Events\SomeEvent());
@@ -60,15 +60,15 @@ final class StaticCallsParsingTest extends TestCase
             'static dispatch call on Event facade with import' => [
                 <<<'CODE'
                 <?php declare(strict_types=1);
-                
+
                 use \Event;
-                
+
                 final class ClassName
                 {
                     public function __construct()
                     {
                     }
-                
+
                     public function classMethod(): void
                     {
                         Event::dispatch(new \App\Events\SomeEvent());
@@ -88,13 +88,13 @@ final class StaticCallsParsingTest extends TestCase
             'static dispatch call on Event facade FQN without import' => [
                 <<<'CODE'
                 <?php declare(strict_types=1);
-                
+
                 final class ClassName
                 {
                     public function __construct()
                     {
                     }
-                
+
                     public function classMethod(): void
                     {
                         \Illuminate\Support\Facades\Event::dispatch(new \App\Events\SomeEvent());
@@ -114,15 +114,15 @@ final class StaticCallsParsingTest extends TestCase
             'static dispatch call on Event facade FQN with import' => [
                 <<<'CODE'
                 <?php declare(strict_types=1);
-                
+
                 use \Illuminate\Support\Facades\Event;
-                
+
                 final class ClassName
                 {
                     public function __construct()
                     {
                     }
-                    
+
                     public function classMethod(): void
                     {
                         Event::dispatch(new \App\Events\SomeEvent());
@@ -142,15 +142,15 @@ final class StaticCallsParsingTest extends TestCase
             'static dispatch call on Event facade FQN with import and alias' => [
                 <<<'CODE'
                 <?php declare(strict_types=1);
-                
+
                 use \Illuminate\Support\Facades\Event as Alias;
-                
+
                 final class ClassName
                 {
                     public function __construct()
                     {
                     }
-                    
+
                     public function classMethod(): void
                     {
                         Alias::dispatch(new \App\Events\SomeEvent());
@@ -170,15 +170,15 @@ final class StaticCallsParsingTest extends TestCase
             'no calls but import as alias' => [
                 <<<'CODE'
                 <?php declare(strict_types=1);
-                
+
                 use \Illuminate\Support\Facades\Event as Alias;
-                
+
                 final class ClassName
                 {
                     public function __construct()
                     {
                     }
-                    
+
                     public function classMethod(): void
                     {
                         // something
@@ -192,15 +192,15 @@ final class StaticCallsParsingTest extends TestCase
             'no calls but normal import' => [
                 <<<'CODE'
                 <?php declare(strict_types=1);
-                
+
                 use \Illuminate\Support\Facades\Event;
-                
+
                 final class ClassName
                 {
                     public function __construct()
                     {
                     }
-                    
+
                     public function classMethod(): void
                     {
                         // something
@@ -214,15 +214,15 @@ final class StaticCallsParsingTest extends TestCase
             'commented static dispatch call on Event facade FQN with import' => [
                 <<<'CODE'
                 <?php declare(strict_types=1);
-                
+
                 use \Illuminate\Support\Facades\Event;
-                
+
                 final class ClassName
                 {
                     public function __construct()
                     {
                     }
-                    
+
                     public function classMethod(): void
                     {
                         // Event::dispatch();
@@ -236,20 +236,20 @@ final class StaticCallsParsingTest extends TestCase
             'multiple static dispatch calls on Event facade FQN with import' => [
                 <<<'CODE'
                 <?php declare(strict_types=1);
-                
+
                 use \Illuminate\Support\Facades\Event;
-                
+
                 final class ClassName
                 {
                     public function __construct()
                     {
                     }
-                    
+
                     public function classMethod(): void
                     {
                         $event1 = new \App\Events\SomeEvent();
                         $event2 = new \App\Events\SomeOtherEvent();
-                    
+
                         Event::dispatch($event1);
                         Event::dispatch($event2);
                     }


### PR DESCRIPTION
Hi

This PR adds try catch to getFunctionCalls calls finder to handle cases where there is invokable class used. It failed to parse name properly and prevented analyzing files.

Added related test and tested manually. Attached screenshots visualize output after this change. Errors are gone and more relationsips appear.

| Before this fix |After this fix  |
|---|---|
| ![image](https://github.com/JonasPardon/laravel-event-visualizer/assets/10627359/f15ae0d0-d4d1-4270-8580-4fd88dd0377c) | ![image](https://github.com/JonasPardon/laravel-event-visualizer/assets/10627359/27cafdae-9998-4836-b7a8-90a470bbfed3) |

Thanks for this nice tool, helps to visualize relationships and interactions way better than just reading code.